### PR TITLE
LOG-19529 Adding github team name to codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@logsearch-shredder
+@rapid7/logsearch-shredder

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@rapid7/dublin-shredder
+* @rapid7/dublin-shredder

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@logsearch-shredder

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@rapid7/logsearch-shredder
+@rapid7/dublin-shredder


### PR DESCRIPTION
## Issue

Link to Jira ticket:  [LOG-19529](https://issues.corp.rapid7.com/browse/LOG-19529)

## Purpose of PR

Add shredder team to codeowners file